### PR TITLE
Add custom MJEmailMessage class

### DIFF
--- a/SciLog/mail.py
+++ b/SciLog/mail.py
@@ -1,0 +1,24 @@
+import json
+
+from django.core.mail import EmailMessage
+
+
+class MJEmailMessage(EmailMessage):
+    def __init__(self, subject='', body='', from_email=None, to=None, bcc=None,
+                 connection=None, attachments=None, headers=None, cc=None,
+                 reply_to=None, template_id=None, variables=None):
+        headers = headers or {}
+        if 'X-MJ-TemplateLanguage' not in headers:
+            headers['X-MJ-TemplateLanguage'] = '1'
+        if 'X-Mailjet-TrackClick' not in headers:
+            headers['X-Mailjet-TrackClick'] = '1'
+        if 'X-Mailjet-TrackOpen' not in headers:
+            headers['X-Mailjet-TrackOpen'] = '1'
+        if template_id:
+            headers['X-MJ-TemplateID'] = template_id
+        if variables:
+            headers['X-MJ-Vars'] = json.dumps(variables)
+        super(MJEmailMessage, self).__init__(
+            subject, body, from_email, to, bcc, connection, attachments,
+            headers, cc, reply_to
+        )

--- a/invitations/signals.py
+++ b/invitations/signals.py
@@ -1,13 +1,11 @@
-import json
-
 from django.db.models.signals import pre_save, post_save
 from django.dispatch import receiver
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from django.core.mail import EmailMessage
 
 from .models import Invitation
 from users.models import Role
+from SciLog.mail import MJEmailMessage
 
 
 @receiver(pre_save, sender=Invitation)
@@ -31,29 +29,15 @@ def send_mail(sender, created, instance, raw, using, update_fields, **kwargs):
             "role": instance.role,
             "url": reverse('invitations_list')
         }
-        if instance.invited is not None:
-            instance.invited.email_user(
-                template_id=settings.MJ_INVITATION_TEMPLATE_ID,
-                variables=json.dumps(variables),
-                from_email=settings.MJ_INVITATION_FROM,
-                fail_silently=settings.DEBUG
-            )
-        else:
-            headers = {
-                'X-MJ-TemplateID': settings.MJ_INVITATION_TEMPLATE_ID,
-                'X-MJ-TemplateLanguage': '1',
-                'X-Mailjet-TrackClick': '1',
-                'X-Mailjet-TrackOpen': '1',
-                'X-MJ-Vars': json.dumps(variables)
-            }
-            email = EmailMessage(
-                subject='',
-                body='',
-                to=[instance.email],
-                from_email=settings.MJ_INVITATION_FROM,
-                headers=headers
-            )
-            email.send(fail_silently=settings.DEBUG)
+        email = MJEmailMessage(
+            subject='',
+            body='',
+            to=[instance.email],
+            from_email=settings.MJ_INVITATION_FROM,
+            template_id=settings.MJ_INVITATION_TEMPLATE_ID,
+            variables=variables
+        )
+        email.send(fail_silently=settings.DEBUG)
 
 
 @receiver(post_save, sender=Invitation)

--- a/users/models.py
+++ b/users/models.py
@@ -2,9 +2,9 @@ from django.contrib.auth.models import AbstractUser
 from django.db import models
 from django.core.exceptions import ValidationError
 from django.apps import apps
-from django.core.mail import EmailMessage
 
 from protocols.models import Protocol
+from SciLog.mail import MJEmailMessage
 
 
 class Role(models.Model):
@@ -175,23 +175,13 @@ class User(AbstractUser):
             from_email=None,
             fail_silently=False,
             **kwargs):
-        kwargs.update(
-            {
-                'headers':
-                    {
-                        'X-MJ-TemplateID': template_id,
-                        'X-MJ-TemplateLanguage': '1',
-                        'X-Mailjet-TrackClick': '1',
-                        'X-Mailjet-TrackOpen': '1',
-                        'X-MJ-Vars': variables
-                    }
-            }
-        )
-        msg = EmailMessage(
+        msg = MJEmailMessage(
             subject=kwargs.pop('subject', ''),
             body=kwargs.pop('body', ''),
             to=[self.email],
             from_email=from_email,
+            template_id=template_id,
+            variables=variables,
             **kwargs
         )
         msg.send(fail_silently=fail_silently)

--- a/users/views.py
+++ b/users/views.py
@@ -1,5 +1,3 @@
-import json
-
 from django.shortcuts import redirect
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -72,7 +70,7 @@ class Register(CreateView):
         }
         self.object.email_user(
             template_id=settings.MJ_EMAIL_CONFIRMATION_TEMPLATE_ID,
-            variables=json.dumps(variables),
+            variables=variables,
             from_email=settings.MJ_EMAIL_CONFIRMATION_FROM,
             fail_silently=settings.DEBUG
         )


### PR DESCRIPTION
To avoid putting default headers everywhere we create MJEmailMessage class that inherits the base EmailMessage django class